### PR TITLE
Feat: add getEntropy XAppMethods method

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,16 @@ module.exports = {
     ...tsJestConfig,
     preset: 'react-native',
     transformIgnorePatterns: [
-        'node_modules/(?!react-native|@react-native|@react-native-community|realm|@react-native-firebase|i18n-js)',
+        `node_modules/(?!${[
+            'react-native',
+            '@react-native',
+            '@react-native-community',
+            'realm',
+            '@react-native-firebase',
+            'i18n-js',
+            '@scure',
+            '@noble',
+        ].join('|')})`,
     ],
     setupFiles: ['./jest.setup.js'],
     collectCoverage: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@react-native-firebase/app": "20.4.0",
         "@react-native-firebase/crashlytics": "20.4.0",
         "@react-native-firebase/messaging": "20.4.0",
+        "@scure/bip32": "^2.2.0",
         "@veriff/react-native-sdk": "7.1.0",
         "bignumber.js": "9.1.2",
         "fuse.js": "7.0.0",
@@ -131,7 +132,6 @@
     "node_modules/@babel/core": {
       "version": "7.24.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.2",
@@ -1724,7 +1724,6 @@
     "node_modules/@babel/preset-env": {
       "version": "7.24.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.24.1",
         "@babel/helper-compilation-targets": "^7.23.6",
@@ -2412,7 +2411,6 @@
       "version": "4.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@cucumber/messages": ">=17.1.1"
       }
@@ -2421,7 +2419,6 @@
       "version": "24.0.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/uuid": "9.0.7",
         "class-transformer": "0.5.1",
@@ -2614,7 +2611,6 @@
     "node_modules/@firebase/app": {
       "version": "0.10.5",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.7",
         "@firebase/logger": "0.4.2",
@@ -2670,7 +2666,6 @@
     "node_modules/@firebase/app-compat": {
       "version": "0.2.35",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.10.5",
         "@firebase/component": "0.6.7",
@@ -2685,8 +2680,7 @@
     },
     "node_modules/@firebase/app-types": {
       "version": "0.9.2",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/app/node_modules/tslib": {
       "version": "2.6.3",
@@ -3113,7 +3107,6 @@
     "node_modules/@firebase/util": {
       "version": "1.9.6",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -3538,7 +3531,6 @@
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/fake-timers": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -5067,7 +5059,6 @@
     "node_modules/@react-native-firebase/app": {
       "version": "20.4.0",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "firebase": "10.12.2",
         "superstruct": "^0.6.2"
@@ -5531,6 +5522,56 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@scure/bip32": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@scure/base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@sideway/address": {
       "version": "4.1.5",
       "license": "BSD-3-Clause",
@@ -5722,7 +5763,6 @@
       "version": "18.2.67",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5835,7 +5875,6 @@
       "version": "7.3.1",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.3.1",
         "@typescript-eslint/types": "7.3.1",
@@ -6146,7 +6185,6 @@
     "node_modules/acorn": {
       "version": "8.11.2",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7231,7 +7269,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -7390,7 +7427,6 @@
         "node >=0.10.0"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "bunyan": "bin/bunyan"
       },
@@ -9323,7 +9359,6 @@
       "version": "8.57.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9416,7 +9451,6 @@
       "version": "9.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -9528,7 +9562,6 @@
       "version": "2.29.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -9727,7 +9760,6 @@
       "version": "6.8.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "aria-query": "^5.3.0",
@@ -9786,7 +9818,6 @@
       "version": "7.34.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlast": "^1.2.4",
@@ -9818,7 +9849,6 @@
       "version": "4.6.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -12324,7 +12354,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -16233,7 +16262,6 @@
       "version": "3.2.5",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -16545,7 +16573,6 @@
     "node_modules/react": {
       "version": "18.2.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -16723,7 +16750,6 @@
     "node_modules/react-native": {
       "version": "0.74.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.6.3",
         "@react-native-community/cli": "13.6.8",
@@ -18913,7 +18939,6 @@
       "version": "5.4.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@react-native-firebase/app": "20.4.0",
     "@react-native-firebase/crashlytics": "20.4.0",
     "@react-native-firebase/messaging": "20.4.0",
+    "@scure/bip32": "^2.2.0",
     "@veriff/react-native-sdk": "7.1.0",
     "bignumber.js": "9.1.2",
     "fuse.js": "7.0.0",

--- a/src/common/libs/__tests__/entropy.test.ts
+++ b/src/common/libs/__tests__/entropy.test.ts
@@ -1,0 +1,14 @@
+/* eslint-disable max-len */
+
+import { deriveEntropy } from '../entropy';
+
+describe('Entropy', () => {
+    // If this changes you have changed how entropy is derived which will break existing apps that rely on this
+    it('deriveEntropy', async () => {
+        const privateKeyHex = '000000000000000000000000000000000000000000000000000000000000000';
+        const appid = 'your_app_id';
+        const salt = 'your_salt';
+        const result = await deriveEntropy(privateKeyHex, appid, salt);
+        expect(result).toBe('e4a470c0aefd47d2162593ae10dd4e63818299c2bd58ce70aa26857c011980e9');
+    });
+});

--- a/src/common/libs/entropy.ts
+++ b/src/common/libs/entropy.ts
@@ -1,0 +1,50 @@
+import { HDKey } from '@scure/bip32';
+import { HexEncoding } from '@common/utils/string';
+import { SHA256 } from './crypto';
+
+const MAGIC_VALUE = 0xd8554d4d; // "XUMM" with high bit set on first byte for hardening
+const HARDENED_VALUE = 0x80000000;
+
+/**
+ * Derive an `HDKey` node down a path of indices.
+ */
+const derivePath = (node: HDKey, indices: number[]): HDKey => {
+    return indices.reduce((current, index) => current.deriveChild(index), node);
+};
+
+/**
+ * Get an array of `uint32 | 0x80000000` values from a hash. The hash is assumed
+ * to be 32 bytes long.
+ */
+const getUint32Array = (hash: Uint8Array): number[] => {
+    const array: number[] = [];
+    const view = new DataView(hash.buffer, hash.byteOffset, hash.byteLength);
+
+    for (let index = 0; index < 8; index++) {
+        const uint32 = view.getUint32(index * 4);
+        array.push((uint32 | HARDENED_VALUE) >>> 0);
+    }
+
+    return array;
+};
+
+/**
+ * Derive deterministic, app-specific entropy from an account's stored private
+ * key using BIP-32. The app id and salt are hashed into a BIP-32 derivation
+ * path, which is then used to derive a private key that is returned as entropy.
+ */
+export const deriveEntropy = async (privateKeyHex: string, appid: string, salt: string): Promise<string> => {
+    const saltHash = await SHA256(salt);
+    const hashHex = await SHA256(`${appid}:${saltHash}`);
+    const computedDerivationPath = getUint32Array(Uint8Array.from(HexEncoding.toBinary(hashHex)));
+
+    // Derive the entropy using BIP-32, prefixed with the magic value.
+    const master = HDKey.fromMasterSeed(Uint8Array.from(HexEncoding.toBinary(privateKeyHex)));
+    const { privateKey: entropy } = derivePath(master, [MAGIC_VALUE, ...computedDerivationPath]);
+
+    if (!entropy) {
+        throw new Error('Failed to derive entropy.');
+    }
+
+    return HexEncoding.toHex(Buffer.from(entropy));
+};

--- a/src/screens/Modal/XAppBrowser/XAppBrowserModal.tsx
+++ b/src/screens/Modal/XAppBrowser/XAppBrowserModal.tsx
@@ -34,6 +34,8 @@ import { GetAppVersionCode } from '@common/helpers/app';
 
 import { Payload, PayloadOrigin } from '@common/libs/payload';
 import { Destination } from '@common/libs/ledger/parser/types';
+import { deriveEntropy } from '@common/libs/entropy';
+import Vault from '@common/libs/vault';
 
 import { StringTypeCheck } from '@common/utils/string';
 
@@ -44,7 +46,7 @@ import NetworkService from '@services/NetworkService';
 import { AccountRepository, CoreRepository, NetworkRepository, ProfileRepository } from '@store/repositories';
 import { AccountModel, NetworkModel } from '@store/models';
 // import { AccessLevels, Themes } from '@store/types';
-import { AccessLevels } from '@store/types';
+import { AccessLevels, EncryptionLevels } from '@store/types';
 
 import { BackendService, NavigationService, PushNotificationsService, StyleService } from '@services';
 import { ApiError } from '@services/ApiService';
@@ -72,6 +74,8 @@ import { ScanModalProps } from '@screens/Modal/Scan';
 import { DestinationPickerModalProps } from '@screens/Modal/DestinationPicker';
 import { ReviewTransactionModalProps } from '@screens/Modal/ReviewTransaction';
 import { PurchaseProductModalProps } from '@screens/Modal/PurchaseProduct';
+import { AuthenticateOverlayProps } from '@screens/Overlay/Authenticate';
+import { PassphraseAuthenticationOverlayProps } from '@screens/Overlay/PassphraseAuthentication';
 
 import LoggerService from '@services/LoggerService';
 
@@ -495,6 +499,51 @@ class XAppBrowserModal extends Component<Props, State> {
         });
     };
 
+    getEntropy = async (data: { salt: string }) => {
+        const { account, app } = this.state;
+        const salt = get(data, 'salt', '');
+
+        if (typeof salt !== 'string') {
+            return;
+        }
+        if (!app || !app.appid) {
+            return;
+        }
+        // only full-access regular accounts hold a private key
+        if (account.accessLevel !== AccessLevels.Full) {
+            this.sendEvent({ method: XAppMethods.GetEntropy, result: undefined, reason: 'NO_PRIV_KEY' });
+            return;
+        }
+
+        const openAndReturnEntropy = async (encryptionKey: string) => {
+            const privateKey = await Vault.open(account.publicKey, encryptionKey);
+            if (!privateKey) {
+                this.sendEvent({ method: XAppMethods.GetEntropy, result: undefined, reason: 'NO_PRIV_KEY' });
+                return;
+            }
+            const entropy = await deriveEntropy(privateKey, app.appid!, salt);
+            this.sendEvent({ method: XAppMethods.GetEntropy, result: entropy });
+        };
+
+        if (account.encryptionLevel === EncryptionLevels.Passcode) {
+            Navigator.showOverlay<AuthenticateOverlayProps>(AppScreens.Overlay.Auth, {
+                canAuthorizeBiometrics: false,
+                onSuccess: () => openAndReturnEntropy(CoreRepository.getSettings().passcode!),
+                onDismissed: () => {
+                    this.sendEvent({ method: XAppMethods.GetEntropy, result: undefined, reason: 'USER_CANCEL' });
+                },
+            });
+        } else if (account.encryptionLevel === EncryptionLevels.Passphrase) {
+            Navigator.showOverlay<PassphraseAuthenticationOverlayProps>(AppScreens.Overlay.PassphraseAuthentication, {
+                account,
+                onSuccess: (passphrase: string) => openAndReturnEntropy(passphrase),
+                onDismissed: () => {
+                    this.sendEvent({ method: XAppMethods.GetEntropy, result: undefined, reason: 'USER_CANCEL' });
+                },
+            });
+        }
+    };
+
     handleCommand = (command: XAppMethods, parsedData: any) => {
         const { app, isAppReady, coreSettings } = this.state;
 
@@ -574,6 +623,9 @@ class XAppBrowserModal extends Component<Props, State> {
                 break;
             case XAppMethods.RequestInAppPurchase:
                 this.requestInAppPurchase(parsedData);
+                break;
+            case XAppMethods.GetEntropy:
+                this.getEntropy(parsedData);
                 break;
             default:
                 break;
@@ -741,6 +793,14 @@ class XAppBrowserModal extends Component<Props, State> {
                 throw new Error('Provided ott is not valid from response!');
             }
 
+            // TODO(willem) remove this once backend returns GetEntropy in the list of supported commands
+            const resolvedPermissions = coreSettings.developerMode
+                ? {
+                      special: permissions?.special ?? [],
+                      commands: [...(permissions?.commands ?? []), toUpper(XAppMethods.GetEntropy)],
+                  }
+                : permissions;
+
             // everything is fine
             this.setState({
                 ott,
@@ -750,7 +810,7 @@ class XAppBrowserModal extends Component<Props, State> {
                     appid: appid || app?.appid,
                     supportUrl: xappSupportUrl,
                     icon,
-                    permissions,
+                    permissions: resolvedPermissions,
                     networks,
                     __ott: app?.__ott || ott,
                 },

--- a/src/screens/Modal/XAppBrowser/types.ts
+++ b/src/screens/Modal/XAppBrowser/types.ts
@@ -86,6 +86,7 @@ export enum XAppMethods {
     Ready = 'ready',
     NetworkSwitch = 'networkSwitch',
     RequestInAppPurchase = 'requestInAppPurchase',
+    GetEntropy = 'getEntropy',
 }
 
 export enum XAppSpecialPermissions {


### PR DESCRIPTION
Adds `getEntropy` xAppMethod addressing https://github.com/XRPL-Labs/Xaman-App/issues/159

The implementation of entropy derivation closely follows [SIP-6](https://metamask.github.io/SIPs/SIPS/sip-6) several differences:
- Switches Keccak for SHA256
- Uses a custom magic number
- Derives using the wallet private key as the root instead of the seed phrase (seed phrase is not available in the vault after creation)

The derivation of entropy is security critical and MUST be stable. Care should be taken to ensure the above modifications preserve correctness from the original SIP. 

---

## Testing

As getEntropy isn't added to the sdk yet it needs a custom event listener to receive the responses. Something like this can work inside your xApp for testing

```typescript
export function requestEntropy(
  salt: string,
  timeoutMs = 30_000,
): Promise<string> {
  return new Promise<string>((resolve, reject) => {
    const ac = new AbortController();
    const { signal } = ac;
    const timer = setTimeout(() => {
      ac.abort();
      reject(new Error("TIMEOUT"));
    }, timeoutMs);
    signal.addEventListener("abort", () => clearTimeout(timer));

    const onMessage = (e: Event): void => {
      let data: any;
      try {
        data = JSON.parse((e as MessageEvent).data);
      } catch {
        return;
      }
      if (data?.method !== "getEntropy") return;

      ac.abort();
      if (data.result) resolve(data.result);
      else reject(new Error(data.reason ?? "NO_RESULT"));
    };

    // iOS delivers on window, Android on document — mirror the SDK.
    window.addEventListener("message", onMessage, { signal });
    document.addEventListener("message", onMessage, { signal });

    Promise.resolve(getXumm().xapp?.customCommand("getEntropy", { salt })).then(
      (r) => {
        if (r instanceof Error) {
          ac.abort();
          reject(r);
        }
      },
    );
  });
}
```