### PR TITLE
Fix transaction template QR/deeplink network detection, offer network switch

### DIFF
--- a/src/screens/Modal/Scan/ScanModal.tsx
+++ b/src/screens/Modal/Scan/ScanModal.tsx
@@ -238,19 +238,33 @@ class ScanModal extends Component<Props, State> {
         let errorMsg = Localize.t('global.theQRIsNotWhatWeExpect');
 
         try {
-            const str = Buffer.from(String(parsed?.jsonhex || ''), 'hex').toString('utf-8');   
+            const str = Buffer.from(String(parsed?.jsonhex || ''), 'hex').toString('utf-8');
             const json = JSON.parse(str);
-           
-            if (
-                json?.NetworkID !== NetworkService.getNetwork().networkId ||
-                NetworkService.getNetwork().networkId > 1024 && !json?.NetworkID
-            ) {
-                errorMsg = Localize.t('payload.payloadForceNetworkError');
-                throw new Error('Invalid network');
+
+            // resolve the network this template is intended for, without NetworkID the template
+            // targets XRPL networks (id <= 1024) as these cannot include NetworkID in txn
+            let templateNetwork;
+
+            if (typeof json?.NetworkID === 'undefined') {
+                if (NetworkService.getNetwork().networkId > 1024) {
+                    errorMsg = Localize.t('payload.payloadForceNetworkError');
+                    throw new Error('Invalid network');
+                }
+            } else {
+                templateNetwork = NetworkRepository.findOne({ networkId: json.NetworkID });
+
+                if (!templateNetwork) {
+                    errorMsg = Localize.t('payload.payloadForceNetworkError');
+                    throw new Error('Invalid network');
+                }
+
+                // NetworkID is populated at signing time based on the connected network
+                delete json.NetworkID;
             }
+
             if (json?.TransactionType === 'TrustSet') {
                 const trustSet = new TrustSet(json);
-        
+
                 const payload = Payload.build(
                     trustSet.JsonForSigning,
                     Localize.t('asset.addingAssetReserveDescription', {
@@ -258,7 +272,12 @@ class ScanModal extends Component<Props, State> {
                         nativeAsset: NetworkService.getNativeAsset(),
                     }),
                 );
-        
+
+                if (templateNetwork) {
+                    // review flow will offer switching if not connected to the declared network
+                    payload.meta.force_network = templateNetwork.key;
+                }
+
                 this.setShouldRead(false);
 
                 setTimeout(() => {

--- a/src/services/LinkingService.ts
+++ b/src/services/LinkingService.ts
@@ -433,12 +433,25 @@ class LinkingService {
             const str = Buffer.from(String(parsed?.jsonhex || ''), 'hex').toString('utf-8');
             const json = JSON.parse(str);
 
-            if (
-                json?.NetworkID !== NetworkService.getNetwork().networkId ||
-                (NetworkService.getNetwork().networkId > 1024 && !json?.NetworkID)
-            ) {
-                errorMsg = Localize.t('payload.payloadForceNetworkError');
-                throw new Error('Invalid network');
+            // resolve the network this template is intended for, without NetworkID the template
+            // targets XRPL networks (id <= 1024) as these cannot include NetworkID in txn
+            let templateNetwork;
+
+            if (typeof json?.NetworkID === 'undefined') {
+                if (NetworkService.getNetwork().networkId > 1024) {
+                    errorMsg = Localize.t('payload.payloadForceNetworkError');
+                    throw new Error('Invalid network');
+                }
+            } else {
+                templateNetwork = NetworkRepository.findOne({ networkId: json.NetworkID });
+
+                if (!templateNetwork) {
+                    errorMsg = Localize.t('payload.payloadForceNetworkError');
+                    throw new Error('Invalid network');
+                }
+
+                // NetworkID is populated at signing time based on the connected network
+                delete json.NetworkID;
             }
 
             if (json?.TransactionType === 'TrustSet') {
@@ -451,6 +464,11 @@ class LinkingService {
                         nativeAsset: NetworkService.getNativeAsset(),
                     }),
                 );
+
+                if (templateNetwork) {
+                    // review flow will offer switching if not connected to the declared network
+                    payload.meta.force_network = templateNetwork.key;
+                }
 
                 setTimeout(() => {
                     Navigator.showModal(


### PR DESCRIPTION
Fixes #96

## Root cause

Both `ScanModal.handleTransactionTemplate` and `LinkingService.handleTransactionTemplate` required the template's `NetworkID` to strictly equal the connected network id. XRPL-family transactions (network id ≤ 1024) never carry a `NetworkID` field, so the documented template QRs (docs.xaman.dev simple-link-qr) always failed on XRPL networks with "This payload is not available on the network you are connected with" (`undefined !== 0`).

## Fix

Network resolution now follows protocol semantics, identically in both handlers:

| Template | Connected network | Result |
|---|---|---|
| no `NetworkID` | XRPL mainnet/testnet/devnet (id ≤ 1024) | ✅ proceeds on connected network |
| no `NetworkID` | Xahau family (id > 1024) | ❌ error (intended network ambiguous — no switch offer) |
| `NetworkID` = known network | same network | ✅ proceeds |
| `NetworkID` = known network (e.g. 21337) | different network | 🔁 review opens, existing Preflight flow offers **Switch network** |
| `NetworkID` unknown | any | ❌ error |

Implementation notes:
- A declared `NetworkID` is resolved via `NetworkRepository` and carried as `payload.meta.force_network`, so the **existing** ReviewTransaction Preflight `checkForcedNetwork` path handles the mismatch UI (including its dev-mode gating for non-Main network types) — no new switching UI introduced.
- `NetworkID` is stripped from the template before building the payload; `Sign.mixin` re-populates it at signing time for networks that require it (id > 1024), keeping the signed tx canonical on whichever network is ultimately used.

## Testing

Verified on iOS simulator (XRPL mainnet, deeplink path `xumm://xaman.app/detect/<hex>`):
1. Issue's exact QR hex (no `NetworkID`) → Review transaction opens: TrustSet XAH/GateHub, limit 100M, `tfSetNoRipple` ✅
2. Same template + `NetworkID: 21337` → "Please switch to Xahau and try again" + Switch network button ✅
3. `NetworkID: 424242` (unknown) → clean error prompt, no switch offer ✅

`npm run tsc` and eslint pass. In-app camera scanner path shares the identical handler code but can't be exercised in the simulator (no camera injection) — worth one real-device scan before merge. Pre-existing, unrelated: `LinkingService.test.ts` crashes on `main` as well (test harness never initializes storage; separate job).