### PR TITLE
Repair stale Jest unit test suites

### DIFF
--- a/src/common/helpers/__tests__/navigator.test.ts
+++ b/src/common/helpers/__tests__/navigator.test.ts
@@ -68,6 +68,12 @@ describe('Navigator helper', () => {
                         backgroundColor: 'transparent',
                         componentBackgroundColor: 'transparent',
                     },
+                    statusBar: {
+                        visible: true,
+                        style: 'light',
+                        backgroundColor: 'transparent',
+                        drawBehind: true,
+                    },
                 },
             },
         });

--- a/src/common/libs/ledger/objects/__tests__/nfTokenOffer.test.ts
+++ b/src/common/libs/ledger/objects/__tests__/nfTokenOffer.test.ts
@@ -34,7 +34,7 @@ describe('NFTokenOffer object', () => {
 
         describe('generateDescription()', () => {
             it('should return the expected description for sell offer', () => {
-                const expectedDescription = `rrrrrrrrrrrrrrrrrrrrrholvtp offered to sell NFT token with ID 00081B5825A08C22787716FA031B432EBBC1B101BB54875F0002D2A400000000 in order to receive 1 XRP${'\n'}The NFT owner is rrrrrrrrrrrrrrrrrrrrrholvtp${'\n'}This offer may only be accepted by rrrrrrrrrrrrrrrrrrrrbzbvji${'\n'}The offer expires at Wednesday, January 24, 2018 1:52 PM unless it is canceled or accepted before then.`;
+                const expectedDescription = `rrrrrrrrrrrrrrrrrrrrrholvtp offered to sell NFT token with ID 00081B5825A08C22787716FA031B432EBBC1B101BB54875F0002D2A400000000 in order to receive 1 XRP${'\n\n'}The NFT owner is rrrrrrrrrrrrrrrrrrrrrholvtp${'\n\n'}This offer may only be accepted by rrrrrrrrrrrrrrrrrrrrbzbvji${'\n\n'}The offer expires at Wednesday, January 24, 2018 1:52 PM unless it is canceled or accepted before then.`;
                 expect(info.generateDescription()).toEqual(expectedDescription);
             });
         });

--- a/src/common/libs/ledger/objects/__tests__/offer.test.ts
+++ b/src/common/libs/ledger/objects/__tests__/offer.test.ts
@@ -31,6 +31,7 @@ describe('Offer object', () => {
                 currency: 'XAG',
                 issuer: 'rrrrrrrrrrrrrrrrrrrrbzbvji',
                 value: '37',
+                mpt_issuance_id: undefined,
             });
         });
     });
@@ -76,6 +77,7 @@ describe('Offer object', () => {
                             currency: 'XAG',
                             effect: 'POTENTIAL_EFFECT',
                             issuer: 'rrrrrrrrrrrrrrrrrrrrbzbvji',
+                            mpt_issuance_id: undefined,
                             value: '37',
                         },
                     ],

--- a/src/common/libs/ledger/parser/common/__tests__/flag.test.ts
+++ b/src/common/libs/ledger/parser/common/__tests__/flag.test.ts
@@ -40,6 +40,7 @@ describe('FlagParser', () => {
 
             expect(parser.get()).toEqual({
                 tfFillOrKill: true,
+                tfHybrid: false,
                 tfImmediateOrCancel: true,
                 tfPassive: false,
                 tfSell: false,

--- a/src/common/libs/ledger/transactions/genuine/__tests__/ammBide.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/ammBide.test.ts
@@ -36,6 +36,7 @@ describe('AMMBid tx', () => {
                 currency: '03930D02208264E2E40EC1B0C09E4DB96EE197B1',
                 issuer: 'rMEdVzU8mtEArzjrN9avm3kA675GX7ez8W',
                 value: '500',
+                mpt_issuance_id: undefined,
             });
         });
     });

--- a/src/common/libs/ledger/transactions/genuine/__tests__/ammCreate.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/ammCreate.test.ts
@@ -31,6 +31,7 @@ describe('AMMCreate tx', () => {
                 currency: 'USD',
                 issuer: 'rhpHaFggC92ELty3n3yDEtuFgWxXWkUFET',
                 value: '10000',
+                mpt_issuance_id: undefined,
             });
             expect(instance.TradingFee).toBe(0.001);
         });

--- a/src/common/libs/ledger/transactions/genuine/__tests__/ammDeposit.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/ammDeposit.test.ts
@@ -27,6 +27,7 @@ describe('AMMDeposit tx', () => {
                 currency: 'USD',
                 issuer: 'rhpHaFggC92ELty3n3yDEtuFgWxXWkUFET',
                 value: '10000',
+                mpt_issuance_id: undefined,
             });
             expect(instance.Amount2).toStrictEqual({
                 currency: 'XRP',
@@ -36,6 +37,7 @@ describe('AMMDeposit tx', () => {
                 currency: 'B3813FCAB4EE68B3D0D735D6849465A9113EE048',
                 issuer: 'rH438jEAzTs5PYtV6CHZqpDpwCKQmPW9Cg',
                 value: '1000',
+                mpt_issuance_id: undefined,
             });
         });
     });

--- a/src/common/libs/ledger/transactions/genuine/__tests__/ammWithdraw.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/ammWithdraw.test.ts
@@ -29,6 +29,7 @@ describe('AMMWithdraw tx', () => {
                 currency: 'USD',
                 issuer: 'rhpHaFggC92ELty3n3yDEtuFgWxXWkUFET',
                 value: '4000',
+                mpt_issuance_id: undefined,
             });
             expect(instance.Amount2).toStrictEqual({
                 currency: 'XRP',
@@ -38,6 +39,7 @@ describe('AMMWithdraw tx', () => {
                 currency: 'B3813FCAB4EE68B3D0D735D6849465A9113EE048',
                 issuer: 'rH438jEAzTs5PYtV6CHZqpDpwCKQmPW9Cg',
                 value: '1000',
+                mpt_issuance_id: undefined,
             });
             expect(instance.EPrice).toStrictEqual({ currency: 'XRP', value: '0.000025' });
         });

--- a/src/common/libs/ledger/transactions/genuine/__tests__/checkCash.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/checkCash.test.ts
@@ -63,6 +63,7 @@ describe('CheckCash', () => {
                 currency: 'USD',
                 issuer: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
                 value: '1',
+                mpt_issuance_id: undefined,
             });
 
             instance.DeliverMin = {
@@ -83,6 +84,7 @@ describe('CheckCash', () => {
                 currency: 'USD',
                 issuer: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
                 value: '1',
+                mpt_issuance_id: undefined,
             });
         });
 

--- a/src/common/libs/ledger/transactions/genuine/__tests__/checkCreate.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/checkCreate.test.ts
@@ -64,6 +64,7 @@ describe('CheckCreate', () => {
                 currency: 'USD',
                 issuer: 'rrrrrrrrrrrrrrrrrrrrBZbvji',
                 value: '1',
+                mpt_issuance_id: undefined,
             });
         });
     });

--- a/src/common/libs/ledger/transactions/genuine/__tests__/clawback.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/clawback.test.ts
@@ -25,6 +25,7 @@ describe('Clawback tx', () => {
                 currency: '594F494E4B000000000000000000000000000000',
                 issuer: 'r3CAQrWrJCFFnNf6mbUtCBUPtuqAb4odbC',
                 value: '1',
+                mpt_issuance_id: undefined,
             });
         });
     });

--- a/src/common/libs/ledger/transactions/genuine/__tests__/credentialAccept.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/credentialAccept.test.ts
@@ -34,7 +34,7 @@ describe('CredentialAccept tx', () => {
 
         describe('generateDescription()', () => {
             it('should return the expected description', () => {
-                const expectedDescription = 'This is an CredentialAccept transaction';
+                const expectedDescription = `This is a CredentialAccept transaction. It a credential issued by rsYxnKtb8JBzfG4hp6sVF3WiVNw2broUFo.${'\n\n'}The credential type is KYC. `;
                 expect(info.generateDescription()).toEqual(expectedDescription);
             });
         });

--- a/src/common/libs/ledger/transactions/genuine/__tests__/credentialCreate.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/credentialCreate.test.ts
@@ -36,7 +36,7 @@ describe('CredentialCreate tx', () => {
 
         describe('generateDescription()', () => {
             it('should return the expected description', () => {
-                const expectedDescription = 'This is an CredentialCreate transaction';
+                const expectedDescription = `This is a CredentialCreate transaction. It involves rsYxnKtb8JBzfG4hp6sVF3WiVNw2broUFo issuing a credential to rH6PVvtAawMNGyxpLvEAkUjpqZNZ1gNT3Z.${'\n\n'}The credential type is KYC. The credential URI is isabel.com/credentials/kyc/alice.`;
                 expect(info.generateDescription()).toEqual(expectedDescription);
             });
         });

--- a/src/common/libs/ledger/transactions/genuine/__tests__/credentialDelete.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/credentialDelete.test.ts
@@ -34,7 +34,7 @@ describe('CredentialDelete tx', () => {
 
         describe('generateDescription()', () => {
             it('should return the expected description', () => {
-                const expectedDescription = 'This is an CredentialDelete transaction';
+                const expectedDescription = `This is a CredentialDelete transaction. It a credential issued by rsYxnKtb8JBzfG4hp6sVF3WiVNw2broUFo.${'\n\n'}The credential type is KYC. `;
                 expect(info.generateDescription()).toEqual(expectedDescription);
             });
         });

--- a/src/common/libs/ledger/transactions/genuine/__tests__/offerCreate.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/offerCreate.test.ts
@@ -22,7 +22,8 @@ describe('OfferCreate tx', () => {
             const instance = new OfferCreate(tx, meta);
 
             expect(instance.GetOfferStatus(tx.Account)).toBe('FILLED');
-            expect(instance.OfferSequence).toBe(94);
+            // fixture only carries Sequence; OfferSequence no longer falls back to it
+            expect(instance.OfferSequence).toBe(undefined);
             expect(instance.Rate).toBe(0.000024271999999999997);
             expect(instance.Expiration).toBe(undefined);
             expect(instance.OfferID).toBe(tx.OfferID);
@@ -31,6 +32,7 @@ describe('OfferCreate tx', () => {
                 currency: 'BTC',
                 issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
                 value: '0.012136',
+                mpt_issuance_id: undefined,
             });
             expect(instance.TakerGets).toStrictEqual({
                 currency: 'XRP',
@@ -43,7 +45,7 @@ describe('OfferCreate tx', () => {
             const instance = new OfferCreate(tx, meta);
 
             expect(instance.GetOfferStatus(tx.Account)).toBe('FILLED');
-            expect(instance.OfferSequence).toBe(112);
+            expect(instance.OfferSequence).toBe(undefined);
             expect(instance.Rate).toBe(0.000025941414017897298);
             expect(instance.Expiration).toBe('2021-09-20T09:38:28.000Z');
 
@@ -55,6 +57,7 @@ describe('OfferCreate tx', () => {
                 currency: 'BTC',
                 issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
                 value: '0.01257',
+                mpt_issuance_id: undefined,
             });
         });
 
@@ -74,6 +77,7 @@ describe('OfferCreate tx', () => {
                 currency: 'BTC',
                 issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
                 value: '0.012136',
+                mpt_issuance_id: undefined,
             });
 
             expect(offer.Expiration).toBe('2011-10-05T14:48:00.000Z');
@@ -94,6 +98,7 @@ describe('OfferCreate tx', () => {
                 currency: 'BTC',
                 issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
                 value: '0.012136',
+                mpt_issuance_id: undefined,
             });
         });
 
@@ -102,7 +107,7 @@ describe('OfferCreate tx', () => {
             const instance = new OfferCreate(tx, meta);
 
             expect(instance.GetOfferStatus('rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ')).toBe('PARTIALLY_FILLED');
-            expect(instance.OfferSequence).toBe(56270334);
+            expect(instance.OfferSequence).toBe(undefined);
             expect(instance.Rate).toBe(0.38076);
             expect(instance.Expiration).toBe(undefined);
 
@@ -114,6 +119,7 @@ describe('OfferCreate tx', () => {
                 currency: '534F4C4F00000000000000000000000000000000',
                 issuer: 'rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz',
                 value: '38.076',
+                mpt_issuance_id: undefined,
             });
         });
 
@@ -121,7 +127,7 @@ describe('OfferCreate tx', () => {
             const { tx, meta }: any = offerCreateTemplates.XRPIOUCANCELED;
             const instance = new OfferCreate(tx, meta);
 
-            expect(instance.OfferSequence).toBe(61160755);
+            expect(instance.OfferSequence).toBe(undefined);
             expect(instance.TakerGets).toStrictEqual({
                 currency: 'XRP',
                 value: '50',
@@ -130,6 +136,7 @@ describe('OfferCreate tx', () => {
                 currency: 'CSC',
                 issuer: 'rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr',
                 value: '11616.66671104',
+                mpt_issuance_id: undefined,
             });
         });
     });
@@ -142,7 +149,7 @@ describe('OfferCreate tx', () => {
             const info = new OfferCreateInfo(instance, { address: tx.Account } as any);
 
             it('should return the expected description', () => {
-                const expectedDescription = `rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ offered to pay 0.01257 BTC in order to receive 484.553386 XRP${'\n'}The exchange rate for this offer is 0.000025941414017897298 BTC/XRP${'\n'}The transaction will also cancel rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ 's existing offer #112${'\n'}The transaction offer ID is: EF963D9313AA45E85610598797D1A65E${'\n'}The offer expires at Monday, September 20, 2021 11:38 AM unless canceled or consumed before then.`;
+                const expectedDescription = `rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ offered to pay 0.01257 BTC in order to receive 484.553386 XRP${'\n'}The exchange rate for this offer is 0.000025941414017897298 BTC/XRP${'\n'}The transaction offer ID is: EF963D9313AA45E85610598797D1A65E${'\n'}The offer expires at Monday, September 20, 2021 11:38 AM unless canceled or consumed before then.`;
                 expect(info.generateDescription()).toEqual(expectedDescription);
             });
 
@@ -170,6 +177,7 @@ describe('OfferCreate tx', () => {
                             currency: 'BTC',
                             effect: 'POTENTIAL_EFFECT',
                             issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+                            mpt_issuance_id: undefined,
                             value: '0.01257',
                         },
                     ],
@@ -202,7 +210,6 @@ describe('OfferCreate tx', () => {
             it('should return the expected description', () => {
                 const expectedDescription = `rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ offered to pay 500 XRP in order to receive 0.012136 BTC
 The exchange rate for this offer is 0.000024271999999999997 BTC/XRP
-The transaction will also cancel rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ 's existing offer #94
 The transaction offer ID is: EF963D9313AA45E85610598797D1A65E`;
                 expect(info.generateDescription()).toEqual(expectedDescription);
             });
@@ -225,6 +232,7 @@ The transaction offer ID is: EF963D9313AA45E85610598797D1A65E`;
                             currency: 'BTC',
                             effect: 'POTENTIAL_EFFECT',
                             issuer: 'rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B',
+                            mpt_issuance_id: undefined,
                             value: '0.012136',
                         },
                         {
@@ -262,8 +270,7 @@ The transaction offer ID is: EF963D9313AA45E85610598797D1A65E`;
 
             it('should return the expected description', () => {
                 const expectedDescription = `rsTQsbTfRkqgUxxs8BToD3VdnENaha9UcY offered to pay 100 XRP in order to receive 38.076 SOLO
-The exchange rate for this offer is 0.38076 SOLO/XRP
-The transaction will also cancel rsTQsbTfRkqgUxxs8BToD3VdnENaha9UcY 's existing offer #56270334`;
+The exchange rate for this offer is 0.38076 SOLO/XRP`;
                 expect(info.generateDescription()).toEqual(expectedDescription);
             });
 
@@ -285,6 +292,7 @@ The transaction will also cancel rsTQsbTfRkqgUxxs8BToD3VdnENaha9UcY 's existing 
                             effect: 'POTENTIAL_EFFECT',
                             currency: '534F4C4F00000000000000000000000000000000',
                             issuer: 'rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz',
+                            mpt_issuance_id: undefined,
                             value: '38.076',
                         },
                         {
@@ -322,8 +330,7 @@ The transaction will also cancel rsTQsbTfRkqgUxxs8BToD3VdnENaha9UcY 's existing 
 
             it('should return the expected description', () => {
                 const expectedDescription = `rQamE9ddZiRZLKRAAzwGKboQ8rQHgesjEs offered to pay 50 XRP in order to receive 11616.66671104 CSC
-The exchange rate for this offer is 232.3333342208 CSC/XRP
-The transaction will also cancel rQamE9ddZiRZLKRAAzwGKboQ8rQHgesjEs 's existing offer #61160755`;
+The exchange rate for this offer is 232.3333342208 CSC/XRP`;
                 expect(info.generateDescription()).toEqual(expectedDescription);
             });
 
@@ -345,6 +352,7 @@ The transaction will also cancel rQamE9ddZiRZLKRAAzwGKboQ8rQHgesjEs 's existing 
                             effect: 'POTENTIAL_EFFECT',
                             currency: 'CSC',
                             issuer: 'rCSCManTZ8ME9EoLrSHHYKW8PPwWMgkwr',
+                            mpt_issuance_id: undefined,
                             value: '11616.66671104',
                         },
                         {
@@ -369,8 +377,7 @@ The transaction will also cancel rQamE9ddZiRZLKRAAzwGKboQ8rQHgesjEs 's existing 
 
             it('should return the expected description', () => {
                 const expectedDescription = `rBeSemGtLaHLZXcK1WxutWR339L9ZUz4gh offered to pay 0.6742741104345 SOLO in order to receive 0.000001 XRP
-The exchange rate for this offer is 674274.1104345 SOLO/XRP
-The transaction will also cancel rBeSemGtLaHLZXcK1WxutWR339L9ZUz4gh 's existing offer #91995334`;
+The exchange rate for this offer is 674274.1104345 SOLO/XRP`;
                 expect(info.generateDescription()).toEqual(expectedDescription);
             });
 
@@ -398,6 +405,7 @@ The transaction will also cancel rBeSemGtLaHLZXcK1WxutWR339L9ZUz4gh 's existing 
                             effect: 'POTENTIAL_EFFECT',
                             currency: '534F4C4F00000000000000000000000000000000',
                             issuer: 'rsoLo2S1kiGeCcn6hCUXVrCpGMWLrRrLZz',
+                            mpt_issuance_id: undefined,
                             value: '0.6742741104345',
                         },
                     ],

--- a/src/common/libs/ledger/transactions/genuine/__tests__/payment.test.ts
+++ b/src/common/libs/ledger/transactions/genuine/__tests__/payment.test.ts
@@ -85,6 +85,7 @@ describe('Payment tx', () => {
                 currency: 'USD',
                 issuer: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
                 value: '1',
+                mpt_issuance_id: undefined,
             });
 
             instance.Destination = 'rXUMMProAS9qHvxooeJMYz5smAsJZvArh';
@@ -102,6 +103,7 @@ describe('Payment tx', () => {
                 currency: 'USD',
                 issuer: 'rrrrrrrrrrrrrrrrrrrrrholvtp',
                 value: '1',
+                mpt_issuance_id: undefined,
             });
 
             instance.SendMax = {
@@ -122,6 +124,7 @@ describe('Payment tx', () => {
                 currency: 'USD',
                 issuer: 'rrrrrrrrrrrrrrrrrrrrrholvtp',
                 value: '1',
+                mpt_issuance_id: undefined,
             });
             instance.DeliverMin = {
                 currency: 'XRP',

--- a/src/components/General/__tests__/__snapshots__/InfoMessage.test.tsx.snap
+++ b/src/components/General/__tests__/__snapshots__/InfoMessage.test.tsx.snap
@@ -110,6 +110,9 @@ exports[`[InfoMessage] renders correctly Info 1`] = `
               "color": "#0030CF",
             },
             {
+              "color": "#0030CF",
+            },
+            {
               "textAlign": "center",
             },
           ]
@@ -348,6 +351,9 @@ exports[`[InfoMessage] should render with icon Info 1`] = `
               "fontFamily": "ProximaNova-Bold",
               "fontSize": 30,
               "textAlign": "center",
+            },
+            {
+              "color": "#0030CF",
             },
             {
               "color": "#0030CF",

--- a/src/components/General/__tests__/__snapshots__/RadioButton.test.tsx.snap
+++ b/src/components/General/__tests__/__snapshots__/RadioButton.test.tsx.snap
@@ -71,18 +71,22 @@ exports[`[RadioButton] renders checked correctly 1`] = `
           {
             "borderColor": "#0030CF",
           },
+          undefined,
         ]
       }
     >
       <View
         style={
-          {
-            "backgroundColor": "#0030CF",
-            "borderRadius": 8,
-            "color": "#0030CF",
-            "height": 15,
-            "width": 15,
-          }
+          [
+            {
+              "backgroundColor": "#0030CF",
+              "borderRadius": 8,
+              "color": "#0030CF",
+              "height": 15,
+              "width": 15,
+            },
+            undefined,
+          ]
         }
       />
     </View>
@@ -108,6 +112,7 @@ exports[`[RadioButton] renders checked correctly 1`] = `
           {
             "color": "#000000",
           },
+          undefined,
         ]
       }
     >
@@ -142,6 +147,7 @@ exports[`[RadioButton] renders checked correctly 1`] = `
           {
             "color": "#000000",
           },
+          undefined,
         ]
       }
     >
@@ -220,6 +226,7 @@ exports[`[RadioButton] renders correctly 1`] = `
             "width": 26,
           },
           false,
+          undefined,
         ]
       }
     />
@@ -245,6 +252,7 @@ exports[`[RadioButton] renders correctly 1`] = `
           {
             "color": "#606885",
           },
+          false,
         ]
       }
     >
@@ -279,6 +287,7 @@ exports[`[RadioButton] renders correctly 1`] = `
           {
             "color": "#606885",
           },
+          false,
         ]
       }
     >

--- a/src/components/General/__tests__/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/General/__tests__/__snapshots__/SearchBar.test.tsx.snap
@@ -80,12 +80,15 @@ exports[`[SearchBar] renders correctly 1`] = `
   >
     <TextInput
       autoCapitalize="none"
+      autoComplete="off"
       autoCorrect={false}
+      keyboardType="visible-password"
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
       placeholder="Please type ..."
       placeholderTextColor="#606885"
+      spellCheck={false}
       style={
         [
           {
@@ -190,12 +193,15 @@ exports[`[SearchBar] should clear text 1`] = `
   >
     <TextInput
       autoCapitalize="none"
+      autoComplete="off"
       autoCorrect={false}
+      keyboardType="visible-password"
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
       placeholder="Please type ..."
       placeholderTextColor="#606885"
+      spellCheck={false}
       style={
         [
           {
@@ -300,12 +306,15 @@ exports[`[SearchBar] should show clear button on text enter 1`] = `
   >
     <TextInput
       autoCapitalize="none"
+      autoComplete="off"
       autoCorrect={false}
+      keyboardType="visible-password"
       onBlur={[Function]}
       onChangeText={[Function]}
       onFocus={[Function]}
       placeholder="Please type ..."
       placeholderTextColor="#606885"
+      spellCheck={false}
       style={
         [
           {

--- a/src/components/General/__tests__/__snapshots__/SecurePinInput.test.tsx.snap
+++ b/src/components/General/__tests__/__snapshots__/SecurePinInput.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`[SecurePinInput] renders correctly 1`] = `
       "selected": undefined,
     }
   }
-  accessible={true}
+  accessible={false}
   focusable={true}
   onClick={[Function]}
   onResponderGrant={[Function]}
@@ -21,14 +21,17 @@ exports[`[SecurePinInput] renders correctly 1`] = `
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
   style={
-    {
-      "alignItems": "center",
-      "justifyContent": "center",
-    }
+    [
+      {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+    ]
   }
   testID="pin-input-container"
 >
   <TextInput
+    accessible={true}
     autoCorrect={false}
     caretHidden={true}
     disableFullscreenUI={true}
@@ -43,6 +46,8 @@ exports[`[SecurePinInput] renders correctly 1`] = `
     value=""
   />
   <View
+    accessibilityHint="Please enter your passcode"
+    accessible={true}
     style={
       [
         {
@@ -167,7 +172,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
       "selected": undefined,
     }
   }
-  accessible={true}
+  accessible={false}
   focusable={true}
   onClick={[Function]}
   onResponderGrant={[Function]}
@@ -177,14 +182,18 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
   onResponderTerminationRequest={[Function]}
   onStartShouldSetResponder={[Function]}
   style={
-    {
-      "alignItems": "center",
-      "justifyContent": "center",
-    }
+    [
+      {
+        "alignItems": "center",
+        "justifyContent": "center",
+      },
+    ]
   }
   testID="pin-input-container"
 >
   <View
+    accessibilityHint="Please enter your passcode"
+    accessible={true}
     style={
       [
         {
@@ -317,6 +326,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
       }
     >
       <View
+        accessibilityLabel="1"
         accessibilityValue={
           {
             "max": undefined,
@@ -372,6 +382,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
         />
       </View>
       <View
+        accessibilityLabel="2"
         accessibilityValue={
           {
             "max": undefined,
@@ -429,6 +440,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
         </Text>
       </View>
       <View
+        accessibilityLabel="3"
         accessibilityValue={
           {
             "max": undefined,
@@ -495,6 +507,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
       }
     >
       <View
+        accessibilityLabel="4"
         accessibilityValue={
           {
             "max": undefined,
@@ -552,6 +565,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
         </Text>
       </View>
       <View
+        accessibilityLabel="5"
         accessibilityValue={
           {
             "max": undefined,
@@ -609,6 +623,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
         </Text>
       </View>
       <View
+        accessibilityLabel="6"
         accessibilityValue={
           {
             "max": undefined,
@@ -675,6 +690,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
       }
     >
       <View
+        accessibilityLabel="7"
         accessibilityValue={
           {
             "max": undefined,
@@ -732,6 +748,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
         </Text>
       </View>
       <View
+        accessibilityLabel="8"
         accessibilityValue={
           {
             "max": undefined,
@@ -789,6 +806,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
         </Text>
       </View>
       <View
+        accessibilityLabel="9"
         accessibilityValue={
           {
             "max": undefined,
@@ -855,6 +873,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
       }
     >
       <View
+        accessibilityLabel="Biometrics"
         accessibilityValue={
           {
             "max": undefined,
@@ -907,6 +926,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
         />
       </View>
       <View
+        accessibilityLabel="0"
         accessibilityValue={
           {
             "max": undefined,
@@ -962,6 +982,7 @@ exports[`[SecurePinInput] renders correctly with virtualKeyboard 1`] = `
         />
       </View>
       <View
+        accessibilityLabel="Backspace"
         accessibilityValue={
           {
             "max": undefined,

--- a/src/components/General/__tests__/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/General/__tests__/__snapshots__/TextInput.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`[TextInput] renders correctly 1`] = `
       style={
         [
           {
-            "color": "#0030CF",
+            "color": undefined,
             "flex": 1,
             "fontFamily": "ProximaNova-Regular",
             "fontSize": 32.14285714285714,

--- a/src/services/__tests__/ApiService.test.ts
+++ b/src/services/__tests__/ApiService.test.ts
@@ -88,7 +88,7 @@ describe('API', () => {
         it(`handle with http error code`, async () => {
             // await ApiService['ping'][method]({ action: '400' }).catch((e) => console.warn(e.message));
             await expect(ApiService.fetch(Endpoints.Ping, 'GET', { action: '400' })).rejects.toMatchObject(
-                new ApiError('Api error 400 {"foo":"bar"}'),
+                new ApiError('API error (non 200) 400 {"foo":"bar"}'),
             );
         });
     });

--- a/src/services/__tests__/LinkingService.test.ts
+++ b/src/services/__tests__/LinkingService.test.ts
@@ -1,5 +1,9 @@
 import { Alert, Linking } from 'react-native';
 
+import DataStorage from '@store/storage';
+import { AccountRepository, CoreRepository } from '@store/repositories';
+import { AccessLevels, EncryptionLevels } from '@store/types';
+
 import { AppScreens } from '@common/constants';
 import { Navigator } from '@common/helpers/navigator';
 import { Payload, PayloadOrigin, XAppOrigin } from '@common/libs/payload';
@@ -10,10 +14,40 @@ import Localize from '@locale';
 import LinkingService from '../LinkingService';
 import NavigationService, { ComponentTypes, RootType } from '../NavigationService';
 
+jest.mock('@services/NetworkService');
+jest.mock('@services/LedgerService');
+
 jest.useFakeTimers();
 
 describe('LinkinService', () => {
     const service = LinkingService;
+
+    const testAccountAddress = 'rXUMMaPpZeZ5amdNwfFCVXhdcTANpigNLL';
+
+    let storage: DataStorage;
+
+    beforeAll(async () => {
+        // handleXrplDestination and friends reach the repositories, back them with a real test store
+        if (DataStorage.isDataStoreFileExist()) {
+            DataStorage.wipe();
+        }
+        storage = new DataStorage();
+        await storage.initialize();
+
+        // handleXrplDestination builds the payment from the default account
+        const account = await AccountRepository.add({
+            address: testAccountAddress,
+            label: 'test account',
+            accessLevel: AccessLevels.Readonly,
+            encryptionLevel: EncryptionLevels.None,
+        });
+        CoreRepository.saveSettings({ account });
+    });
+
+    afterAll(() => {
+        DataStorage.wipe();
+        storage.close();
+    });
 
     describe('Service initialize', () => {
         it('should initialize and set root listener', async () => {
@@ -141,36 +175,42 @@ describe('LinkinService', () => {
                 );
             });
 
-            it('should route user to Payment screen with destination info and valid amount', async () => {
-                const navigatorSpy = jest.spyOn(Navigator, 'push');
+            it('should build a payment payload for destination with valid amount and show review screen', async () => {
+                const navigatorSpy = jest.spyOn(Navigator, 'showModal');
                 const mockURL =
                     'https://xaman.app/detect/request:rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ?dt=123&amount=1.337';
 
                 const destination = {
                     to: 'rwietsevLFg8XSmG3bEZzFein1g8RBqWDZ',
                     tag: 123,
-                    amount: '1.337',
                 };
 
-                jest.spyOn(CodecUtils, 'NormalizeDestination').mockReturnValue({
-                    to: destination.to,
-                    tag: destination.tag,
+                jest.spyOn(CodecUtils, 'NormalizeDestination').mockReturnValue(destination);
+
+                const handleXrplDestinationSpy = jest.spyOn(service, 'handleXrplDestination');
+
+                service.handle(mockURL);
+
+                // handle() kicks off the async handler without awaiting it
+                await handleXrplDestinationSpy.mock.results[0].value;
+
+                expect(navigatorSpy).toHaveBeenCalledWith(
+                    AppScreens.Modal.ReviewTransaction,
+                    { componentType: ComponentTypes.Modal, payload: expect.any(Payload) },
+                    { modalPresentationStyle: 'fullScreen' },
+                );
+
+                const { payload } = navigatorSpy.mock.calls[0][1] as { payload: Payload };
+                expect(payload.payload.request_json).toMatchObject({
+                    TransactionType: 'Payment',
+                    Account: testAccountAddress,
+                    Destination: destination.to,
+                    DestinationTag: destination.tag,
+                    Amount: '1337000',
                 });
 
-                await service.handle(mockURL);
-                jest.runAllTimers();
-                expect(navigatorSpy).toHaveBeenCalledWith(
-                    AppScreens.Transaction.Payment,
-                    {
-                        componentType: ComponentTypes.Screen,
-                        scanResult: {
-                            to: destination.to,
-                            tag: destination.tag,
-                        },
-                        amount: destination.amount,
-                    },
-                    {},
-                );
+                handleXrplDestinationSpy.mockRestore();
+                navigatorSpy.mockRestore();
             });
         });
         describe('XApp', () => {


### PR DESCRIPTION
Test-only changes — no app code touched.

## What
- **`LinkingService.test.ts` crashed the whole Jest run** (unhandled `TypeError` killing the Node process, aborting `npm test` mid-run): the suite never initialized DataStorage while `handleXrplDestination` now reaches `CoreRepository.getDefaultAccount()`. Fixed by booting a real Realm test store per the established `storage.test.ts` pattern (`new DataStorage()` + `initialize()`, wipe/close in `afterAll`), creating a default account through `AccountRepository`, and enabling the existing `@services/NetworkService` / `@services/LedgerService` mocks. The stale "route to Payment screen" expectation now asserts the current behavior: a generated `Payment` payload presented in the ReviewTransaction modal.
- **Stale expectations updated to current app behavior** (verified against the intentional app commits that changed them):
  - `mpt_issuance_id: undefined` now present on non-native Amount parse results (MPT support) — payment, checkCash, checkCreate, clawback, AMM*, offer, offerCreate
  - `OfferSequence` no longer falls back to `Sequence` (b86fccc0) — offerCreate assertions + descriptions lose the "will also cancel existing offer" line
  - Credential tx descriptions are implemented now — credentialAccept/Create/Delete
  - NFTokenOffer description joins sentences with blank lines
  - OfferCreate flags gained `tfHybrid`; overlay options gained `statusBar`; `ApiError` message is now `API error (non 200) …`
- **Refreshed 10 component snapshots** (InfoMessage, RadioButton, SearchBar, SecurePinInput, TextInput) — benign diffs from styling/theming changes (incl. `StyleService.select()` markers rendering unresolved under Jest).

## Result
`npm test`: 114 suites passed, 2 pre-existing skips (`describe.skip`), 720 tests, no runner crash (~1 min with coverage).

## Notes (not addressed here)
- GitHub workflows (unit + e2e) trigger on `master`/`develop` only — the repo branch is `main`, so CI test gates never fire.
- Detox e2e is unexercised; `e2e/helpers/simulator.js` still log-filters on `process == "XUMM"` (binary is now Xaman).